### PR TITLE
mingw-w64/gcc-14 error for implicit declaration of function

### DIFF
--- a/src/LibOb_strptime.c
+++ b/src/LibOb_strptime.c
@@ -140,6 +140,9 @@
 // GetSystemTime(&st);
 // vsnprintf_s
 
+#ifdef _WIN32
+#define __STDC_WANT_LIB_EXT1__ 1
+#endif
 #include <wchar.h>
 #include <sec_api/string_s.h>
 #include <stdio.h>

--- a/src/LibOb_strptime.c
+++ b/src/LibOb_strptime.c
@@ -140,6 +140,7 @@
 // GetSystemTime(&st);
 // vsnprintf_s
 
+#include <wchar.h>
 #include <sec_api/string_s.h>
 #include <stdio.h>
 #include "LibOb_strptime.h"


### PR DESCRIPTION
mingw-w64 build for zvbi errors due to gcc-14 implicit declaration of function.

See issue https://github.com/zapping-vbi/zvbi/issues/43 for more details.