### PR TITLE
Fix for static declaration of ‘sincos’ follows non-static declaration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,7 @@ AC_CHECK_FUNCS([alarm dup2 gethostbyaddr gethostbyname getopt_long gettimeofday
 		inet_ntoa localtime_r memmove memset mkdir modf munmap
 		nl_langinfo putenv select setenv setlocale socket strcasecmp
 		strchr strdup strerror strncasecmp strndup strrchr strstr
-		strtol strtoul tzset strptime getaddrinfo ffs __builtin_ffs])
+		strtol strtoul tzset strptime getaddrinfo ffs __builtin_ffs sincos])
 
 AM_CONDITIONAL(HAVE_STRPTIME, [test "x$HAVE_STRPTIME" = xyes])
 
@@ -111,28 +111,6 @@ dnl do not have a specific macro provided by autoconf. Upgrading these to
 dnl autoconf 2.71 required additional quotations and usages of "AC_LANG_SOURCE".
 dnl "Noteworthy changes in autoconf version 2.66 through 2.68"
 dnl <https://autotools.info/forwardporting/autoconf.html>
-
-dnl sincos() is a GNU extension (a macro, not a function).
-dnl If not present we use a replacement.
-AC_MSG_CHECKING([for sincos])
-AC_LINK_IFELSE([AC_LANG_SOURCE([
-#include <stdio.h>
-#include <math.h>
-int main (void) {
-double s, c;
-/* Make sure the compiler does not optimize sincos() away
-   so the linker can confirm its availability. */
-scanf ("%f", &s);
-sincos (s, &s, &c);
-printf ("%f %f", s, c);
-return 0;
-}
-])],[
-  AC_MSG_RESULT([yes])
-  AC_DEFINE(HAVE_SINCOS, 1, [Define if the sincos() function is available])
-],[
-  AC_MSG_RESULT([no])
-])
 
 dnl log2() is a GNU extension (a macro, not a function).
 dnl If not present we use a replacement.


### PR DESCRIPTION
configure.ac: Move sincos function check to AC_CHECK_FUNCS

Patch for issue #49 