### PR TITLE
Use standard va_copy(), not GNU __va_copy()

### DIFF
--- a/src/export.c
+++ b/src/export.c
@@ -1472,7 +1472,7 @@ vbi_export_vprintf		(vbi_export *		e,
 		return TRUE;
 	}
 
-	__va_copy (ap2, ap);
+	va_copy (ap2, ap);
 
 	offset = e->buffer.offset;
 
@@ -1509,7 +1509,7 @@ vbi_export_vprintf		(vbi_export *		e,
 		}
 
 		/* vsnprintf() may advance ap. */
-		__va_copy (ap, ap2);
+		va_copy (ap, ap2);
 	}
 
 	_vbi_export_malloc_error (e);

--- a/src/misc.c
+++ b/src/misc.c
@@ -156,7 +156,7 @@ _vbi_vasprintf			(char **		dstp,
 	buf = NULL;
 	size = 64;
 
-	__va_copy (ap2, ap);
+	va_copy (ap2, ap);
 
 	for (;;) {
 
@@ -183,7 +183,7 @@ _vbi_vasprintf			(char **		dstp,
 		}
 
 		/* vsnprintf() may advance ap. */
-		__va_copy (ap, ap2);
+		va_copy (ap, ap2);
 	}
 
 	vbi_free (buf);

--- a/src/misc.h
+++ b/src/misc.h
@@ -423,9 +423,9 @@ _vbi_time_max			(void)
 }
 #endif
 
-/* __va_copy is a GNU extension. */
-#ifndef __va_copy
-#  define __va_copy(ap1, ap2) do { ap1 = ap2; } while (0)
+/* va_copy is C99. */
+#ifndef va_copy
+#  define va_copy(ap1, ap2) do { ap1 = ap2; } while (0)
 #endif
 
 /* Use this instead of strncpy(). strlcpy() is a BSD extension. */


### PR DESCRIPTION
This is another musl fix.  Last time I tested on aarch64, and didn't encounter this problem, but I've come across it now that I've tried building zvbi for musl on x86_64 as well.

---

`va_copy()` was standardized in C99.  My musl toolchain provides `va_copy()`, not `__va_copy()`.  The Glibc documentation [recommends](https://sourceware.org/glibc/manual/2.40/html_node/Argument-Macros.html#index-va_005fcopy-1) using `va_copy()` if defined, and otherwise falling back to an assignment.